### PR TITLE
Cleanup improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # IntelliJ files
 .idea/
+*.iml
 =======
 # Local .terraform directories
 **/.terraform/*

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,9 +1,36 @@
 #!/bin/bash
+LIGHTBLUE='\033[1;34m'
+NO_COLOUR='\033[0m'
 
-cd terraform/state || exit
+echo -e "${LIGHTBLUE}"
+echo "==========================================="
+echo "| Destroying VPC and networking resources |"
+echo "==========================================="
+echo -e "${NO_COLOUR}"
+
+cd terraform/network || exit
+terraform destroy -auto-approve
+rm -rf .terraform
+
+echo -e "${LIGHTBLUE}"
+echo "=============================================="
+echo "| Migrating terraform state from s3 to local |"
+echo "=============================================="
+echo -e "${NO_COLOUR}"
+
+cd ../state || exit
+# Comment out s3 backend configuration
+sed -i '1,11 s/./#&/' main.tf
+terraform init -force-copy
+
+echo -e "${LIGHTBLUE}"
+echo "==========================================="
+echo "| Destroying s3 bucket and DynamoDB table |"
+echo "==========================================="
+echo -e "${NO_COLOUR}"
+
+terraform destroy
+
 rm -rf .terraform
 rm terraform.tfstate
 rm terraform.tfstate.backup
-
-cd ../network || exit
-rm -rf .terraform

--- a/terraform/state/main.tf
+++ b/terraform/state/main.tf
@@ -17,6 +17,8 @@ provider "aws" {
 resource "aws_s3_bucket" "terraform_state" {
   bucket = "{{PROJECT_PREFIX}}-terraform-state"
 
+  force_destroy = true
+
   lifecycle {
     prevent_destroy = false
   }


### PR DESCRIPTION
This PR considerably simplifies the process of cleaning up after the execution of our setup.sh script. We no longer need to empty the state s3 bucket before deleting it. Additionally, the script will now handle the destruction of all terraform resources, including migrating the terraform state back from the s3 bucket to the local machine, so that it may be destroyed. 