### PR TITLE
Fix up setup and cleanup scripts for OS compatibility

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -20,7 +20,11 @@ echo -e "${NO_COLOUR}"
 
 cd ../state || exit
 # Comment out s3 backend configuration
-sed -i '1,11 s/./#&/' main.tf
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' '1,11 s/./#&/' main.tf
+else
+    sed -i '1,11 s/./#&/' main.tf
+fi
 terraform init -force-copy
 
 echo -e "${LIGHTBLUE}"
@@ -29,7 +33,7 @@ echo "| Destroying s3 bucket and DynamoDB table |"
 echo "==========================================="
 echo -e "${NO_COLOUR}"
 
-terraform destroy
+terraform destroy -auto-approve
 
 rm -rf .terraform
 rm terraform.tfstate

--- a/setup.sh
+++ b/setup.sh
@@ -36,7 +36,12 @@ cd terraform/state || exit
 terraform init
 terraform apply -auto-approve
 
-sed -i 's/#//g' main.tf
+# Uncomment terraform block in state main.tf file
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' 's/#//g' main.tf
+else
+    sed -i 's/#//g' main.tf
+fi
 
 echo -e "${LIGHTBLUE}"
 echo "=========================================="


### PR DESCRIPTION
This PR makes sure that all sed commands work on both MacOS and Linux. Additionally it adds in a few things missed in the previous PR, such as an -auto-approve flag on the last terraform destroy.